### PR TITLE
using the new $settings array 

### DIFF
--- a/sync-module/sync_controller.php
+++ b/sync-module/sync_controller.php
@@ -5,7 +5,7 @@ defined('EMONCMS_EXEC') or die('Restricted access');
 
 function sync_controller()
 {
-    global $linked_modules_dir,$path,$session,$route,$mysqli,$redis,$user,$feed_settings,$log_location;
+    global $settings, $linked_modules_dir, $session, $route, $mysqli, $redis, $feed_settings, $log_location;
 
     $result = '#UNDEFINED#';
 
@@ -24,7 +24,11 @@ function sync_controller()
     
     if ($route->action == "view") {
         $route->format = "html";
-        return view("Modules/sync/sync_view.php",array('version'=>1));
+        return view("Modules/sync/sync_view.php", array(
+            'version' => 1,
+            'redis_enabled' => $settings['redis']['enabled'],
+            'route' => $route
+        ));
     }
     
     // 1. User enters username, password and host of remote installation

--- a/sync-module/sync_view.php
+++ b/sync-module/sync_view.php
@@ -1,4 +1,3 @@
-<?php global $path,$redis_enabled,$route; ?>
 <style>
 .syncprogress {
     background-color:#7bc3e2;
@@ -63,7 +62,6 @@ var subaction = "<?php echo $route->subaction; ?>";
 if (!subaction || subaction=="") subaction = "feeds";
 
 var redis_enabled = <?php echo $redis_enabled; ?>;
-var path = "<?php echo $path; ?>";
 //is remote var used and usefull ?
 //var remote = false;
 var feeds = [];


### PR DESCRIPTION
work was done recently to combine all the global settings variables to a single `$settings[]` array.
https://github.com/emoncms/emoncms/issues/1346

this pull request makes use of this single global `$settings` array
imported the $settings variable to the controller
passed the redis settings variable to sync_view
removed unrequired global variables in sync_view