### PR TITLE
Add missing member variable in sync_model.php to fix issue #36

### DIFF
--- a/sync-module/sync_model.php
+++ b/sync-module/sync_model.php
@@ -20,6 +20,7 @@ class Sync
     private $connect_timeout = 5;
     private $total_timeout = 10;
     private $log;
+    private $feed;
 
     public function __construct($mysqli,$feed)
     {


### PR DESCRIPTION
Issue #36 was caused by the $feed member variable in the Sync class not being delcared in the class. This was permitted prior to php 8.2 but will now raise a warning. The warning corrupts the JSON output preventing the function from working.

Tests:
 - Sync several feed from an upstream stable emoncms instance